### PR TITLE
Fix broken parsing for non-query code blocks

### DIFF
--- a/coredns/MANIFEST
+++ b/coredns/MANIFEST
@@ -2,7 +2,7 @@
 	"ID": "io.gravwell.coredns",
 	"Name": "CoreDNS",
 	"Desc": "This kit provides ready-to-roll dashboards, queries, templates, playbooks, and actionables for analyzing DNS.",
-	"Version": 4,
+	"Version": 5,
 	"MinVersion": {
 		"Major": 3,
 		"Minor": 4,

--- a/coredns/playbook/e21ac76c-7dd7-46a9-b77d-f7c00915bfc9.body
+++ b/coredns/playbook/e21ac76c-7dd7-46a9-b77d-f7c00915bfc9.body
@@ -28,14 +28,14 @@ See the [Gravwell CoreDNS Github Repo](https://github.com/gravwell/coredns) for 
 
 Gravwell is built into CoreDNS as an optional plugin, which must be built from source using the following commands:
 
-```
+<pre>
 go get github.com/coredns/coredns
 pushd $GOPATH/src/github.com/coredns/coredns/
 sed -i 's/metadata:metadata/metadata:metadata\ngravwell:github.com\/gravwell\/coredns/g' plugin.cfg
 go generate
 CGO_ENABLED=0 go build -o /tmp/coredns
 popd
-```
+</pre>
 
 The statically linked CoreDNS server with the Gravwell plugin will be located at /tmp/coredns.
 
@@ -46,7 +46,7 @@ See the [CoreDNS](https://coredns.io) website for more information.
 
 Below is an example CoreDNS configuration that invokes the Gravwell plugin. It provides a path to a Gravwell indexer, authentication secret, tag to ingest to, and most importantly - sets the encoding mode to JSON - which is expected by the CoreDNS kit.
 
-```
+<pre>
 .:53 {
   forward . 8.8.8.8:53 8.8.4.4:53 9.9.9.9:53
   errors stdout
@@ -66,7 +66,7 @@ Below is an example CoreDNS configuration that invokes the Gravwell plugin. It p
    #Max-Cache-Size-MB 1024
   }
 }
-```
+</pre>
 
 # Inspecting DNS Queries
 

--- a/grok/MANIFEST
+++ b/grok/MANIFEST
@@ -2,7 +2,7 @@
 	"ID": "io.gravwell.grok",
 	"Name": "Grok",
 	"Desc": "The Grok kit provides some documentation and a pattern resource file of Grok patterns for data extraction within Gravwell.",
-	"Version": 2,
+	"Version": 3,
 	"MinVersion": {
 		"Major": 3,
 		"Minor": 4,

--- a/grok/playbook/bda6e5ae-6ff9-466d-8854-320fd7165fcb.body
+++ b/grok/playbook/bda6e5ae-6ff9-466d-8854-320fd7165fcb.body
@@ -6,24 +6,28 @@ This is where grok comes in, grok uses abstracted tokens so that mere mortals ca
 
 To really drive home how much power grok can provide, let's look at a complete regular expression designed to extract every field in an Apache Combined Access Log:
 
-```(?P<ip>\S+) (?P<remote_log_name>\S+) (?P<userid>\S+) \[(?P<date>\S+) ?(?P<timezone>\S+)?\] \"(?P<request_method>\S+) (?P<path>\S+) (?P<request_version>HTTP/\d+\.?\d*)?\" (?P<status>\d+) (?P<length>\d+) \"(?P<referrer>[^\"]+)\" \"(?P<user_agent>[^\"]+)\"```
+<pre>
+(?P<ip>\S+) (?P<remote_log_name>\S+) (?P<userid>\S+) \[(?P<date>\S+) ?(?P<timezone>\S+)?\] \"(?P<request_method>\S+) (?P<path>\S+) (?P<request_version>HTTP/\d+\.?\d*)?\" (?P<status>\d+) (?P<length>\d+) \"(?P<referrer>[^\"]+)\" \"(?P<user_agent>[^\"]+)\"
+</pre>
 
 I consider myself above average when it comes to regular expressions, but that is barely readable.  You might even say it's too hard to grok.
 
 If we were to use grok, we could replace all that mess with one token:
 
-```%{COMBINEDAPACHELOG}```
+<pre>
+%{COMBINEDAPACHELOG}
+</pre>
 
 Grok is basically a macro system for regular expressions. Under the hood, grok identifies known tokens and performs a recursive expansion to generate a complete regular expression.
 
 #List of patterns
 
-The following are a list of patterns present in this kit. View the `grok` resource file for further details into these patterns or you can view the file here: https://raw.githubusercontent.com/gravwell/resources/master/grok/all.grok
+The following are a list of patterns present in this kit. View the resource file named "grok" for further details on these patterns, or you can view the file here: https://raw.githubusercontent.com/gravwell/resources/master/grok/all.grok
 
 Full documentation for the grok module can be found in our docs at https://docs.gravwell.io/docs/#!search/grok/grok.md
 
 
-```
+<pre>
 COMMONAPACHELOG
 COMBINEDAPACHELOG
 
@@ -287,4 +291,4 @@ REDISLOG1
 REDISLOG2
 
 RUBY_LOGGER
-```
+</pre>

--- a/ipmi/MANIFEST
+++ b/ipmi/MANIFEST
@@ -2,7 +2,7 @@
 	"ID": "io.gravwell.ipmi",
 	"Name": "IPMI",
 	"Desc": "An IPMI kit that pairs with the Gravwell IPMI ingester.",
-	"Version": 3,
+	"Version": 4,
 	"MinVersion": {
 		"Major": 4,
 		"Minor": 1,

--- a/ipmi/playbook/c6032ccd-790e-4361-ab10-1620b6d98272.body
+++ b/ipmi/playbook/c6032ccd-790e-4361-ab10-1620b6d98272.body
@@ -6,10 +6,10 @@ Data from IPMI comes in a variety of formats, though the majority of systems sup
 
 SEL entries contain a decription of the event, the sensor that triggered it, and potentially more information. A typical set of SEL entries might look something like this:
 
-`
+<pre>
 1 | 06/23/2020 | 00:00:32 | Power Supply #0xc9 | Failure detected () | Deasserted
 2 | 06/26/2020 | 23:31:38 | Power Supply #0xc9 | Failure detected () | Asserted
-`
+</pre>
 
 Gravwell provides a simple [IPMI ingester](https://docs.gravwell.io/#!ingesters/ingesters.md#IPMI_Ingester) that can collect Sensor Data Record (SDR) and System Event Log (SEL) records from any number of IPMI devices.
 
@@ -31,7 +31,7 @@ Deploying the IPMI ingester is similar to any other Gravwell ingester. The inges
 
 Below is an example IPMI ingester configuration. It provides a path to a Gravwell indexer and the authentication secret in the Global section. In the IPMI stanza, it specifies a tag to ingest to and describes two IPMI targets, with authentication credentials for those targets. You can declare as many IPMI stanzas as you need, and you can group IPMI devices that share the same authentication configuration into a single stanza. 
 
-```
+<pre>
 [Global]
 Ingest-Secret = IngestSecrets
 Connection-Timeout = 0
@@ -53,7 +53,7 @@ Log-File=/opt/gravwell/log/ipmi.log
 	Tag-Name=ipmi
 	Rate=60 # poll every 60 seconds
 	#Source-Override="DEAD::BEEF" #override the source for just this Queue 
-```
+</pre>
 
 # Inspecting IPMI Data
 

--- a/linux_syslog/MANIFEST
+++ b/linux_syslog/MANIFEST
@@ -3,7 +3,7 @@
 	"Name": "Linux Syslog",
 	"Desc": "Provides tools for working with Linux system logs, including ssh, sudo, and cron.",
 	"Readme": "# Linux Syslog Kit\r\n\r\nThis kit provides useful tools for working with system logs from Linux machines. It includes dashboards, queries, actionables, and templates built around logs from the SSH daemon, the cron daemon, and the sudo system.\r\n\r\nWe recommend installing the plain syslog kit (io.gravwell.syslog) as well, but this kit does *not* depend on it.",
-	"Version": 1,
+	"Version": 2,
 	"MinVersion": {
 		"Major": 4,
 		"Minor": 1,

--- a/linux_syslog/playbook/f7aedf96-7574-404f-9329-517e88cdaaae.body
+++ b/linux_syslog/playbook/f7aedf96-7574-404f-9329-517e88cdaaae.body
@@ -4,25 +4,25 @@ This kit provides dashboards and queries which operate on syslog data originatin
 
 The easiest way to get syslog entries into Gravwell is with the [Simple Relay ingester](https://docs.gravwell.io/#!ingesters/simple_relay.md). The documentation contains more complete instructions for configuration, but in brief, you can configure the ingester to accept syslog messages over TCP with a stanza like this:
 
-```
+<pre>
 [Listener "syslog"]
     Bind-String=0.0.0.0:601
     Reader-Type=RFC5424
-```
+</pre>
 
 To use UDP instead:
 
-```
+<pre>
 [Listener "syslog"]
     Bind-String=udp://0.0.0.0:514
     Reader-Type=RFC524
-```
+</pre>
 
 Once you have configured Simple Relay, you just need to make your Linux systems direct syslog to it. Configuration details will vary, but here's how to make rsyslogd send logs to syslog.example.com over TCP:
 
-```
+<pre>
 *.* @@syslog.example.com:601;RSYSLOG_SyslogProtocol23Format
-```
+</pre>
 
 # Dashboards
 

--- a/zeek/MANIFEST
+++ b/zeek/MANIFEST
@@ -2,7 +2,7 @@
 	"ID": "io.gravwell.beta.zeek",
 	"Name": "Gravwell Zeek",
 	"Desc": "The Gravwell Zeek Kit provides a baseline set of queries, dashboards, templates, and investigative resources for the Zeek Network Security Monitor.",
-	"Version": 5,
+	"Version": 6,
 	"MinVersion": {
 		"Major": 4,
 		"Minor": 0,

--- a/zeek/playbook/3ad9b6d6-d891-478c-880e-01bcb1893e7a.body
+++ b/zeek/playbook/3ad9b6d6-d891-478c-880e-01bcb1893e7a.body
@@ -99,24 +99,24 @@ The Zeek data set contains many highly orthogonal data sources, including unique
 Gravwell supports two indexing engines designed to provide different capabilities and tradeoffs.  Both engines can perform very well with the Zeek datasets.  The bloom engine can provide a balance of good performance and minimal disk usage while the index engine provides precise indexing performance in exchange for greater disk and memory usage.  Regardless of the chosen engine, Gravwell recommends that Zeek data be fulltext indexed with the "ignoreFloat" and "ignoreUUID" options.  The following well configurations work well with Zeek data:
 
 ### Bloom Engine
-```
+<pre>
 [Storage-Well "zeek"]
 	Location=/opt/gravwell/storage/zeek
 	Tags=zeek*
 	Accelerator-Name=fulltext
 	Accelerator-Args="-ignoreFloat -ignoreUUID"
 	Accelerator-Engine-Override=bloom
-```
+</pre>
 
 ### Index Engine
-```
+<pre>
 [Storage-Well "zeek"]
 	Location=/opt/gravwell/storage/zeek
 	Tags=zeek*
 	Accelerator-Name=fulltext
 	Accelerator-Args="-ignoreFloat -ignoreUUID"
 	Accelerator-Engine-Override=index
-```
+</pre>
 
 ## Additional Information
 The "Zeek" and "Bro" names are owned by the [Zeek Community](https://zeek.org).


### PR DESCRIPTION
When we added query parsing checks for inline queries in playbooks, this had the side-effect
of printing a "Query parsing error" alongside every non-query code block in the playbooks.
By wrapping non-query blocks in HTML pre tags instead, we get rid of that.