### PR TITLE
fixing issue #100, kv now needs the -dall so we up min version to 5.2.1

### DIFF
--- a/linux_syslog/MANIFEST
+++ b/linux_syslog/MANIFEST
@@ -3,11 +3,11 @@
 	"Name": "Linux Syslog",
 	"Desc": "Provides tools for working with Linux system logs, including ssh, sudo, and cron.",
 	"Readme": "# Linux Syslog Kit\r\n\r\nThis kit provides useful tools for working with system logs from Linux machines. It includes dashboards, queries, actionables, and templates built around logs from the SSH daemon, the cron daemon, and the sudo system.\r\n\r\nWe recommend installing the plain syslog kit (io.gravwell.syslog) as well, but this kit does *not* depend on it.",
-	"Version": 5,
+	"Version": 6,
 	"MinVersion": {
-		"Major": 4,
-		"Minor": 1,
-		"Point": 9
+		"Major": 5,
+		"Minor": 2,
+		"Point": 1
 	},
 	"MaxVersion": {
 		"Major": 0,

--- a/linux_syslog/searchlibrary/a0b84e45-82af-4068-8c01-eb998186c2e7.query
+++ b/linux_syslog/searchlibrary/a0b84e45-82af-4068-8c01-eb998186c2e7.query
@@ -1,4 +1,4 @@
 tag=$SYSLOG syslog Appname==sudo Message Hostname
 | regex -e Message "(?P<sudoing_user>\S+) : (?P<args>.+)"
-| kv -e args -ld -sep "=" -d " ; " TTY PWD COMMAND
+| kv -e args -ld -sep "=" -dall " ; " TTY PWD COMMAND
 | table TIMESTAMP Hostname sudoing_user TTY PWD COMMAND


### PR DESCRIPTION
```
tag=$SYSLOG syslog Appname==sudo Message Hostname
| regex -e Message "(?P<sudoing_user>\S+) : (?P<args>.+)"
| kv -e args -ld -sep "=" -d " ; " TTY PWD COMMAND
| table TIMESTAMP Hostname sudoing_user TTY PWD COMMAND
```
->
```
tag=$SYSLOG syslog Appname==sudo Message Hostname
| regex -e Message "(?P<sudoing_user>\S+) : (?P<args>.+)"
| kv -e args -ld -sep "=" -dall " ; " TTY PWD COMMAND
| table TIMESTAMP Hostname sudoing_user TTY PWD COMMAND
```

This PR addresses https://github.com/gravwell/kits/issues/100