### PR TITLE
Fix corelight actionable & template

### DIFF
--- a/corelight/MANIFEST
+++ b/corelight/MANIFEST
@@ -2,7 +2,7 @@
 	"ID": "io.gravwell.corelight",
 	"Name": "Gravwell Corelight",
 	"Desc": "The Gravwell Corelight Kit provides a baseline set of queries, dashboards, templates, and investigative resources for JSON logs originating from Corelight devices.",
-	"Version": 1,
+	"Version": 2,
 	"MinVersion": {
 		"Major": 5,
 		"Minor": 2,

--- a/corelight/pivot/d2ea37bd-69ce-4135-b90c-b8aca740de6e.meta
+++ b/corelight/pivot/d2ea37bd-69ce-4135-b90c-b8aca740de6e.meta
@@ -6,7 +6,7 @@
 		"menuLabel": "UID",
 		"triggers": [
 			{
-				"pattern": "/(\\s|^)(?\u003cuid\u003e(C|F)([a-zA-Z0-9]{13,17}))(\\s|$)/g",
+				"pattern": "/(\\s|^|\")(?<uid>(C|F)([a-zA-Z0-9]{13,19}))(\\s|$|\")/g",
 				"hyperlink": true
 			}
 		],

--- a/corelight/template/4d882ff0-d052-4999-8799-afc6b21e1fd2.query
+++ b/corelight/template/4d882ff0-d052-4999-8799-afc6b21e1fd2.query
@@ -1,1 +1,1 @@
-tag=corelight_* fields -d "\t" [1]==%%UID%% as uid
+tag=corelight_* json uid==%%UID%%


### PR DESCRIPTION
We had two issues:

* The regex for UIDs was too strict on length, and didn't support surrounding quotes, so it wasn't working with JSON very well.
* One of the templates was still using fields to extract data instead of json.

Addresses #109 and #110

