### PR TITLE
adding in overview dashboard and capture loss autoextractor

### DIFF
--- a/corelight/MANIFEST
+++ b/corelight/MANIFEST
@@ -981,12 +981,27 @@
 			"Name": "corelight_x509",
 			"Type": 4,
 			"Hash": "0000000000000000000000000000000000000000000000000000000000000000"
+		},
+		{
+			"Name": "4a6a2042-faaf-4d0a-8fa4-df8a90d3aa65",
+			"Type": 3,
+			"Hash": "0000000000000000000000000000000000000000000000000000000000000000"
+		},
+		{
+			"Name": "corelight_capture_loss",
+			"Type": 4,
+			"Hash": "0000000000000000000000000000000000000000000000000000000000000000"
 		}
+
 	],
 	"Dependencies": [
 		{
 			"ID": "io.gravwell.networkenrichment",
 			"MinVersion": 6
+		},
+		{
+			"ID": "io.gravwell.gravwell",
+			"MinVersion": 7
 		}
 	],
 	"ConfigMacros": null

--- a/corelight/autoextractor/corelight_capture_loss.meta
+++ b/corelight/autoextractor/corelight_capture_loss.meta
@@ -1,0 +1,16 @@
+{
+	"Name": "corelight_capture_loss",
+	"Desc": "JSON extraction for tag corelight_capture_loss",
+	"Module": "json",
+	"Tag": "corelight_capture_loss",
+	"Labels": [
+		"corelight",
+		"status",
+		"capture loss"
+	],
+	"UID": 1,
+	"GIDs": null,
+	"Global": true,
+	"UUID": "1b167bf6-1f8a-4971-8e8b-cf1766a59ada",
+	"LastUpdated": "2023-05-08T14:12:59.869093566Z"
+}

--- a/corelight/autoextractor/corelight_capture_loss.params
+++ b/corelight/autoextractor/corelight_capture_loss.params
@@ -1,0 +1,1 @@
+_write_ts _node ts_delta gaps acks _path _system_name ts peer percent_lost

--- a/corelight/dashboard/4a6a2042-faaf-4d0a-8fa4-df8a90d3aa65.meta
+++ b/corelight/dashboard/4a6a2042-faaf-4d0a-8fa4-df8a90d3aa65.meta
@@ -22,7 +22,7 @@
 				"color": null
 			},
 			{
-				"alias": "Search 3",
+				"alias": "Overview",
 				"query": "tag=_aggs_tags ax tag~corelight | stats sum(entries) by tag | chart sum by tag limit 64",
 				"color": null
 			},

--- a/corelight/dashboard/4a6a2042-faaf-4d0a-8fa4-df8a90d3aa65.meta
+++ b/corelight/dashboard/4a6a2042-faaf-4d0a-8fa4-df8a90d3aa65.meta
@@ -1,0 +1,196 @@
+{
+	"UUID": "4a6a2042-faaf-4d0a-8fa4-df8a90d3aa65",
+	"Name": "Corelight Overview",
+	"Description": "Corelight status dashboard showing basic data rates, EPS, and summary statistics for corelight data streams",
+	"Data": {
+		"timeframe": {
+			"durationString": null,
+			"timeframe": "P1DT",
+			"timezone": null,
+			"start": null,
+			"end": null
+		},
+		"searches": [
+			{
+				"alias": "Entry Rates",
+				"query": "tag=_aggs_tags ax tag~corelight | stats sum(entries) by tag | chart sum by tag limit 64",
+				"color": null
+			},
+			{
+				"alias": "Data Rates",
+				"query": "tag=_aggs_tags ax tag~corelight | stats sum(bytes) as data by tag | chart data by tag limit 64",
+				"color": null
+			},
+			{
+				"alias": "Search 3",
+				"query": "tag=_aggs_tags ax tag~corelight | stats sum(entries) by tag | chart sum by tag limit 64",
+				"color": null
+			},
+			{
+				"alias": "License Usage",
+				"query": "tag=corelight json _path==\"corelight_license_capacity\" mbps | stats mean(mbps) as MBPS | chart MBPS",
+				"color": null
+			},
+			{
+				"alias": "Totals",
+				"query": "tag=_aggs_tags ax tag~corelight | stats sum(entries) as \"Entries\" sum(bytes) as \"Data\" | numbercard Entries Data",
+				"color": null
+			},
+			{
+				"alias": "Non-routed Paths",
+				"query": "tag=corelight json _path | stats count by _path | wordcloud count",
+				"color": null
+			},
+			{
+				"alias": "Capture Loss",
+				"query": "tag=corelight_capture_loss ax | stats max(percent_lost) as lost by _node | chart lost by _node ",
+				"color": null
+			}
+		],
+		"tiles": [
+			{
+				"id": 6603436583113566,
+				"title": "Entry Rates",
+				"renderer": "barChart",
+				"hideZoom": true,
+				"span": {
+					"col": 6,
+					"row": 5,
+					"x": 0,
+					"y": 3
+				},
+				"searchesIndex": 0,
+				"rendererOptions": {
+					"Stack": "stacked",
+					"Orientation": "v",
+					"XAxisSplitLine": "no",
+					"YAxisSplitLine": "no",
+					"IncludeOther": "yes",
+					"LogScale": "no"
+				}
+			},
+			{
+				"id": 1683551990390,
+				"title": "Data Rates",
+				"renderer": "barChart",
+				"hideZoom": true,
+				"span": {
+					"col": 6,
+					"row": 5,
+					"x": 0,
+					"y": 8
+				},
+				"searchesIndex": 1,
+				"rendererOptions": {
+					"Stack": "stacked",
+					"Orientation": "v",
+					"XAxisSplitLine": "no",
+					"YAxisSplitLine": "no",
+					"IncludeOther": "yes",
+					"LogScale": "no"
+				}
+			},
+			{
+				"id": 16835520961412,
+				"title": "Overview",
+				"renderer": "overview",
+				"hideZoom": true,
+				"span": {
+					"col": 6,
+					"row": 3,
+					"x": 0,
+					"y": 0
+				},
+				"searchesIndex": 2,
+				"rendererOptions": {}
+			},
+			{
+				"id": 1683552476249,
+				"title": "License Usage",
+				"renderer": "lineChart",
+				"hideZoom": true,
+				"span": {
+					"col": 3,
+					"row": 3,
+					"x": 6,
+					"y": 0
+				},
+				"searchesIndex": 3,
+				"rendererOptions": {
+					"Stack": "stacked",
+					"Orientation": "v",
+					"XAxisSplitLine": "no",
+					"YAxisSplitLine": "no",
+					"IncludeOther": "yes",
+					"LogScale": "no"
+				}
+			},
+			{
+				"id": 1683552495649,
+				"title": "Totals",
+				"renderer": "numberCard",
+				"hideZoom": true,
+				"span": {
+					"col": 6,
+					"row": 3,
+					"x": 6,
+					"y": 3
+				},
+				"searchesIndex": 4,
+				"rendererOptions": {
+					"Stack": "stacked",
+					"Orientation": "v",
+					"XAxisSplitLine": "no",
+					"YAxisSplitLine": "no",
+					"IncludeOther": "yes",
+					"LogScale": "no"
+				}
+			},
+			{
+				"id": 1683553273059,
+				"title": "Non-routed Paths",
+				"renderer": "wordcloud",
+				"hideZoom": true,
+				"span": {
+					"col": 6,
+					"row": 7,
+					"x": 6,
+					"y": 6
+				},
+				"searchesIndex": 5,
+				"rendererOptions": {}
+			},
+			{
+				"id": 1683553305527,
+				"title": "Capture Loss",
+				"renderer": "barChart",
+				"hideZoom": true,
+				"span": {
+					"col": 3,
+					"row": 3,
+					"x": 9,
+					"y": 0
+				},
+				"searchesIndex": 6,
+				"rendererOptions": {
+					"Stack": "stacked",
+					"Smoothing": "smooth",
+					"Orientation": "v",
+					"XAxisSplitLine": "no",
+					"YAxisSplitLine": "no",
+					"IncludeOther": "yes",
+					"ConnectNulls": "no",
+					"LogScale": "no"
+				}
+			}
+		],
+		"linkZooming": true,
+		"grid": {},
+		"version": 2
+	},
+	"Labels": [
+		"corelight",
+		"overview",
+		"status"
+	]
+}


### PR DESCRIPTION
Adds new dashboard and extractor for corelight_capture_loss

Kit also now depends on the Gravwell kit so we can use the tag aggregates

![Screenshot from 2023-05-08 08-40-58](https://user-images.githubusercontent.com/108431167/236853945-44c742f8-7e64-4652-a981-d4364df3a816.png)
