### PR TITLE
fixing field names for corelight

### DIFF
--- a/corelight/dashboard/213587770620490.meta
+++ b/corelight/dashboard/213587770620490.meta
@@ -59,7 +59,7 @@
 				"searchID": 5592859914
 			},
 			{
-				"query": "tag=corelight_ssh ax host_key != \"-\" | unique host_key resp_host | stats count(host_key) by resp_host | table resp_host count",
+				"query": "tag=corelight_ssh ax host_key != \"-\" | unique host_key \"id.resp_h\" | stats count(host_key) by \"id.resp_h\" | table \"id.resp_h\" count",
 				"alias": null
 			},
 			{

--- a/corelight/searchlibrary/2f72164f-0752-4a4d-b133-e7e2fa28cdc4.query
+++ b/corelight/searchlibrary/2f72164f-0752-4a4d-b133-e7e2fa28cdc4.query
@@ -1,1 +1,1 @@
-tag=corelight_smb* ax | ip "id.orig_h"~PRIVATE "id.resp_h"~PRIVATE | fdg "id.orig_h" resp
+tag=corelight_smb* ax | ip "id.orig_h"~PRIVATE "id.resp_h"~PRIVATE | fdg "id.orig_h" "id.resp_h"

--- a/corelight/searchlibrary/756a41c4-c412-43bf-929c-095df4895472.query
+++ b/corelight/searchlibrary/756a41c4-c412-43bf-929c-095df4895472.query
@@ -1,1 +1,1 @@
-tag=corelight_smb* ax | unique "id.orig_h" | geoip "id.orig_h".Location | heatmap orig
+tag=corelight_smb* ax | unique "id.orig_h" | geoip "id.orig_h".Location | heatmap "id.orig_h"

--- a/corelight/searchlibrary/dae7ec36-d2b2-489a-99ff-542474b549ec.query
+++ b/corelight/searchlibrary/dae7ec36-d2b2-489a-99ff-542474b549ec.query
@@ -1,1 +1,1 @@
-tag=corelight_smb* ax | unique "id.resp_h" | geoip "id.resp_h".Location | heatmap resp
+tag=corelight_smb* ax | unique "id.resp_h" | geoip "id.resp_h".Location | heatmap "id.resp_h"


### PR DESCRIPTION
There were just a few query library and dashboards with leftover `resp_host` and `orig_host` from the zeek conversion

This PR addresses https://github.com/gravwell/kits/issues/129