### PR TITLE
Fix(#170): syslog kit: hostname and appname regex is too strict #170

### DIFF
--- a/linux_syslog/pivot/3ee74567-fc6a-4ca9-84d1-7a49e18bcf2f.meta
+++ b/linux_syslog/pivot/3ee74567-fc6a-4ca9-84d1-7a49e18bcf2f.meta
@@ -118,7 +118,7 @@
 		"menuLabel": null,
 		"triggers": [
 			{
-				"pattern": "/\\w+/g",
+				"pattern": "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$/g",
 				"hyperlink": false
 			}
 		]

--- a/linux_syslog/pivot/3ee74567-fc6a-4ca9-84d1-7a49e18bcf2f.meta
+++ b/linux_syslog/pivot/3ee74567-fc6a-4ca9-84d1-7a49e18bcf2f.meta
@@ -118,7 +118,7 @@
 		"menuLabel": null,
 		"triggers": [
 			{
-				"pattern": "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$/g",
+				"pattern": "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9\.])$/g",
 				"hyperlink": false
 			}
 		]

--- a/syslog/pivot/6236f4a7-a494-42bb-b357-806f399aa5fa.meta
+++ b/syslog/pivot/6236f4a7-a494-42bb-b357-806f399aa5fa.meta
@@ -6,7 +6,7 @@
 		"menuLabel": "Syslog",
 		"triggers": [
 			{
-				"pattern": "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$/g",
+				"pattern": "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9\.])$/g",
 				"hyperlink": false
 			}
 		],

--- a/syslog/pivot/6236f4a7-a494-42bb-b357-806f399aa5fa.meta
+++ b/syslog/pivot/6236f4a7-a494-42bb-b357-806f399aa5fa.meta
@@ -6,7 +6,7 @@
 		"menuLabel": "Syslog",
 		"triggers": [
 			{
-				"pattern": "/\\w+/g",
+				"pattern": "/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$/g",
 				"hyperlink": false
 			}
 		],


### PR DESCRIPTION
Updates the reges for the syslog and linux_syslog kit to support '-'.

This PR addresses: https://github.com/gravwell/kits/issues/170