### PR TITLE
Corelight kit: Fix "Invalid SSL Certificates" query, name

### DIFF
--- a/corelight/searchlibrary/82efb53a-ba7d-4497-9267-7b4439e9b9fe.meta
+++ b/corelight/searchlibrary/82efb53a-ba7d-4497-9267-7b4439e9b9fe.meta
@@ -1,6 +1,6 @@
 {
-	"Name": "Invalid SSL Certificates",
-	"Description": "SSL connections which failed due to bad certificates",
+	"Name": "SSL Alert Protocol Messages",
+	"Description": "SSL connections with associated alert messages",
 	"GUID": "82efb53a-ba7d-4497-9267-7b4439e9b9fe",
 	"Labels": [
 		"corelight",

--- a/corelight/searchlibrary/82efb53a-ba7d-4497-9267-7b4439e9b9fe.query
+++ b/corelight/searchlibrary/82efb53a-ba7d-4497-9267-7b4439e9b9fe.query
@@ -1,1 +1,3 @@
-tag=corelight_ssl ax last_alert!="-" | alias "id.orig_h" client "id.resp_h" server last_alert alert | table client server server_name alert established
+tag=corelight_ssl json -s last_alert "id.orig_h" "id.resp_h" server_name established
+| alias "id.orig_h" client "id.resp_h" server last_alert alert
+| table client server server_name last_alert established


### PR DESCRIPTION
- Name: The value for last_alert refers to the SSL Alert Protocol (https://datatracker.ietf.org/doc/html/rfc5246#section-7.2) and the name now reflects that
- Query: Rather than add a line to "require" an EV, switch ax to json and added -s...for efficiency

This PR addresses https://github.com/gravwell/kits/issues/180