### PR TITLE
fix styling and extra pipes in a few query library items

### DIFF
--- a/corelight/searchlibrary/99f518cb-da24-4170-b0d0-ff4d393ef306.query
+++ b/corelight/searchlibrary/99f518cb-da24-4170-b0d0-ff4d393ef306.query
@@ -1,8 +1,8 @@
-tag=corelight_conn ax service duration orig_bytes resp_bytes orig_pkts resp_pkts |
-stats mean(orig_bytes) as "Average Downstream Traffic"
+tag=corelight_conn ax service duration orig_bytes resp_bytes orig_pkts resp_pkts
+| stats mean(orig_bytes) as "Average Downstream Traffic"
 mean(resp_bytes) as "Average Upstream Traffic"
 mean(duration) as "Average Connection Duration"
 mean(orig_pkts) as "Average Downstream Packets"
-mean(resp_pkts) as "Average Upstream Packets" by service |
-eval if ( service == "-" ) { service = "unknown"; } |
-table service "Average Connection Duration" "Average Downstream Traffic" "Average Downstream Packets" "Average Upstream Traffic" "Average Upstream Packets"
+mean(resp_pkts) as "Average Upstream Packets" by service
+| eval if ( service == "-" ) { service = "unknown"; }
+| table service "Average Connection Duration" "Average Downstream Traffic" "Average Downstream Packets" "Average Upstream Traffic" "Average Upstream Packets"

--- a/zeek/searchlibrary/cd689d30-ac19-4640-8336-c7aa6135c03d.query
+++ b/zeek/searchlibrary/cd689d30-ac19-4640-8336-c7aa6135c03d.query
@@ -3,6 +3,6 @@ tag=zeekconn ax service duration orig_bytes resp_bytes orig_pkts resp_pkts
   mean(resp_bytes) as "Average Upstream Traffic"
   mean(duration) as "Average Connection Duration"
   mean(orig_pkts) as "Average Downstream Packets"
-  mean(resp_pkts) as "Average Upstream Packets" by service |
-| eval if (service == "-") {service = "unknown";} |
+  mean(resp_pkts) as "Average Upstream Packets" by service
+| eval if (service == "-") {service = "unknown";}
 | table service "Average Connection Duration" "Average Downstream Traffic" "Average Downstream Packets" "Average Upstream Traffic" "Average Upstream Packets"


### PR DESCRIPTION
styling in one of the zeek kit's query library didn't match the guide and a corelight kit query library item had too many pipes.