### PR TITLE
Fix min version on windows kits

### DIFF
--- a/sysmon/MANIFEST
+++ b/sysmon/MANIFEST
@@ -7,7 +7,7 @@
 	"MinVersion": {
 		"Major": 5,
 		"Minor": 4,
-		"Point": 0
+		"Point": 11
 	},
 	"MaxVersion": {
 		"Major": 0,

--- a/windows/MANIFEST
+++ b/windows/MANIFEST
@@ -5,9 +5,9 @@
 	"Readme": "",
 	"Version": 1,
 	"MinVersion": {
-		"Major": 4,
-		"Minor": 1,
-		"Point": 0
+		"Major": 5,
+		"Minor": 4,
+		"Point": 11
 	},
 	"MaxVersion": {
 		"Major": 0,

--- a/windows_resource/MANIFEST
+++ b/windows_resource/MANIFEST
@@ -5,9 +5,9 @@
 	"Readme": "",
 	"Version": 4,
 	"MinVersion": {
-		"Major": 4,
-		"Minor": 1,
-		"Point": 0
+		"Major": 5,
+		"Minor": 4,
+		"Point": 11
 	},
 	"MaxVersion": {
 		"Major": 0,


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue. Updates the min version for the Sysmon, Windows, and Windows Resource kits. There was a bug fixed in v5.4.11 as described in the changelog:
![image](https://github.com/user-attachments/assets/08fd350d-468c-4422-872a-1ad4b5b291b9)
