### PR TITLE
Update build_test.yml - Go Version 1.25.8

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.6
+          go-version: 1.25.8
           cache: false
 
       - name: build kitctl


### PR DESCRIPTION
Updating Go version to 1.25.8 (previously 1.25.6)

<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses a Github workflows build issue.

## This PR proposes...

Updating installed Go version from 1.25.6 -> 1.25.8
